### PR TITLE
Feature/팀 api #45

### DIFF
--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -3,9 +3,12 @@ import { ApplyController } from 'src/controllers/apply.controller';
 import { AuthController } from 'src/controllers/auth.controller';
 import { WhitelistController } from 'src/controllers/whitelist.controller';
 
+import { TeamController } from './team.controller';
+
 export default [
   AuthController,
   AboutController,
   ApplyController,
   WhitelistController,
+  TeamController,
 ];

--- a/src/controllers/team.controller.ts
+++ b/src/controllers/team.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Get,
+  Param,
   Post,
   Request,
   UseGuards,
@@ -9,6 +10,7 @@ import {
 import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { LoginAuthGuard } from 'src/services/auth/guard/login.guard';
 import { GetTeamListResponseDto } from 'src/services/team/dto/get-team-list.dto';
+import { GetTeamResponseDto } from 'src/services/team/dto/get-team.dto';
 import {
   PostTeamRequestDto,
   PostTeamResponseDto,
@@ -50,5 +52,19 @@ export class TeamController {
   ): Promise<PostTeamResponseDto> {
     const userId = req.user.userId;
     return await this.teamService.createTeam(userId, body);
+  }
+
+  @Get('/:id')
+  @UseGuards(LoginAuthGuard)
+  @ApiOperation({
+    summary: '팀 조회',
+    description: '특정 팀을 조회합니다.',
+  })
+  @ApiCreatedResponse({
+    description: '팀 정보',
+    type: GetTeamResponseDto,
+  })
+  async findTeamById(@Param('id') id: string): Promise<GetTeamResponseDto> {
+    return await this.teamService.findTeamById(id);
   }
 }

--- a/src/controllers/team.controller.ts
+++ b/src/controllers/team.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { LoginAuthGuard } from 'src/services/auth/guard/login.guard';
+import { GetTeamListResponseDto } from 'src/services/team/dto/get-team-list.dto';
+import { TeamService } from 'src/services/team/team.service';
+
+@Controller('team')
+export class TeamController {
+  constructor(private readonly teamService: TeamService) {}
+
+  @Get('/')
+  @UseGuards(LoginAuthGuard)
+  async findAll(): Promise<GetTeamListResponseDto> {
+    return await this.teamService.findAll();
+  }
+}

--- a/src/controllers/team.controller.ts
+++ b/src/controllers/team.controller.ts
@@ -54,17 +54,19 @@ export class TeamController {
     return await this.teamService.createTeam(userId, body);
   }
 
-  @Get('/:id')
+  @Get('/:teamId')
   @UseGuards(LoginAuthGuard)
   @ApiOperation({
     summary: '팀 조회',
-    description: '특정 팀을 조회합니다.',
+    description: '팀 id를 통해 팀 정보를 조회합니다.',
   })
   @ApiCreatedResponse({
     description: '팀 정보',
     type: GetTeamResponseDto,
   })
-  async findTeamById(@Param('id') id: string): Promise<GetTeamResponseDto> {
-    return await this.teamService.findTeamById(id);
+  async findTeamById(
+    @Param('teamId') teamId: string,
+  ): Promise<GetTeamResponseDto> {
+    return await this.teamService.findTeamById(teamId);
   }
 }

--- a/src/controllers/team.controller.ts
+++ b/src/controllers/team.controller.ts
@@ -1,14 +1,24 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { LoginAuthGuard } from 'src/services/auth/guard/login.guard';
 import { GetTeamListResponseDto } from 'src/services/team/dto/get-team-list.dto';
 import { TeamService } from 'src/services/team/team.service';
 
 @Controller('team')
+@ApiTags('Team')
 export class TeamController {
   constructor(private readonly teamService: TeamService) {}
 
   @Get('/')
   @UseGuards(LoginAuthGuard)
+  @ApiOperation({
+    summary: '전체 팀 목록 조회',
+    description: '모든 팀 목록을 조회합니다.',
+  })
+  @ApiCreatedResponse({
+    description: '팀 목록',
+    type: GetTeamListResponseDto,
+  })
   async findAll(): Promise<GetTeamListResponseDto> {
     return await this.teamService.findAll();
   }

--- a/src/controllers/team.controller.ts
+++ b/src/controllers/team.controller.ts
@@ -36,6 +36,14 @@ export class TeamController {
 
   @Post('/')
   @UseGuards(LoginAuthGuard)
+  @ApiOperation({
+    summary: '팀 생성',
+    description: '팀을 생성합니다.',
+  })
+  @ApiCreatedResponse({
+    description: '생성된 팀의 id',
+    type: PostTeamResponseDto,
+  })
   async createTeam(
     @Request() req,
     @Body() body: PostTeamRequestDto,

--- a/src/controllers/team.controller.ts
+++ b/src/controllers/team.controller.ts
@@ -1,7 +1,18 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { LoginAuthGuard } from 'src/services/auth/guard/login.guard';
 import { GetTeamListResponseDto } from 'src/services/team/dto/get-team-list.dto';
+import {
+  PostTeamRequestDto,
+  PostTeamResponseDto,
+} from 'src/services/team/dto/post-team.dto';
 import { TeamService } from 'src/services/team/team.service';
 
 @Controller('team')
@@ -21,5 +32,15 @@ export class TeamController {
   })
   async findAll(): Promise<GetTeamListResponseDto> {
     return await this.teamService.findAll();
+  }
+
+  @Post('/')
+  @UseGuards(LoginAuthGuard)
+  async createTeam(
+    @Request() req,
+    @Body() body: PostTeamRequestDto,
+  ): Promise<PostTeamResponseDto> {
+    const userId = req.user.userId;
+    return await this.teamService.createTeam(userId, body);
   }
 }

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -15,6 +15,7 @@ import { ApplyQuestion } from './apply-question.entity';
 import { ApplySetting } from './apply-setting.entity';
 import { ApplyValue } from './apply-value.entity';
 import { Apply } from './apply.entity';
+import { TeamLink } from './team-link.entity';
 
 export default [
   About,
@@ -29,6 +30,7 @@ export default [
   Meetup,
   Post,
   Team,
+  TeamLink,
   User,
   Vote,
   Whitelist,

--- a/src/entities/team-link.entity.ts
+++ b/src/entities/team-link.entity.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+
+import { BaseEntity } from './base.entity';
+import { Team } from './team.entity';
+
+@Entity({ name: 'team_link' })
+export class TeamLink extends BaseEntity {
+  @ApiProperty({ description: '팀 소개 링크' })
+  @Column({ name: 'link' })
+  link: string;
+
+  @ManyToOne(() => Team, (team) => team.links, { nullable: true })
+  @JoinColumn({ name: 'team_id' })
+  team: Team;
+}

--- a/src/entities/team.entity.ts
+++ b/src/entities/team.entity.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { BaseEntity } from 'src/entities/base.entity';
 import { File } from 'src/entities/file.entity';
 import { Meetup } from 'src/entities/meetup.entity';
@@ -15,20 +16,25 @@ import {
 
 @Entity({ name: 'team' })
 export class Team extends BaseEntity {
+  @ApiProperty({ description: '팀 이름' })
   @Column({ name: 'name' })
   name: string;
 
+  @ApiProperty({ description: '팀장' })
   @ManyToOne(() => User, (user) => user.leadTeams)
   @JoinColumn({ name: 'leader_id' })
   leader: User;
 
+  @ApiProperty({ description: '팀원' })
   @ManyToMany(() => User, (user) => user.teams)
   @JoinTable({ name: 'user_team' })
   member: User[];
 
+  @ApiProperty({ description: '팀 설명 제목' })
   @Column({ name: 'description_title' })
   descriptionTitle: string;
 
+  @ApiProperty({ description: '팀 설명 내용' })
   @Column({ name: 'description_content' })
   descriptionContent: string;
 

--- a/src/entities/team.entity.ts
+++ b/src/entities/team.entity.ts
@@ -14,6 +14,8 @@ import {
   OneToMany,
 } from 'typeorm';
 
+import { TeamLink } from './team-link.entity';
+
 @Entity({ name: 'team' })
 export class Team extends BaseEntity {
   @ApiProperty({ description: '팀 이름' })
@@ -47,4 +49,7 @@ export class Team extends BaseEntity {
   @ManyToMany(() => Meetup, (meetup) => meetup.teams)
   @JoinTable({ name: 'team_meetup' })
   meetup: Meetup[];
+
+  @OneToMany(() => TeamLink, (teamLink) => teamLink.team)
+  links: TeamLink[];
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -6,6 +6,8 @@ import { AuthService } from 'src/services/auth/auth.service';
 import { UserService } from 'src/services/user/user.service';
 import { WhitelistService } from 'src/services/whitelist/whitelist.service';
 
+import { TeamService } from './team/team.service';
+
 export default [
   AboutService,
   ApplyService,
@@ -14,4 +16,5 @@ export default [
   ConfigService,
   JwtService,
   AuthService,
+  TeamService,
 ];

--- a/src/services/team/dto/get-team-list.dto.ts
+++ b/src/services/team/dto/get-team-list.dto.ts
@@ -8,9 +8,11 @@ class TeamListDto extends PickType(Team, [
   'descriptionTitle',
   'descriptionContent',
 ]) {
+  @ApiProperty({ description: '팀원' })
   member: string[];
 }
 
 export class GetTeamListResponseDto {
+  @ApiProperty({ type: [TeamListDto] })
   teams: TeamListDto[];
 }

--- a/src/services/team/dto/get-team-list.dto.ts
+++ b/src/services/team/dto/get-team-list.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { baseDtoKey } from 'src/entities/base.entity';
+import { Team } from 'src/entities/team.entity';
+
+class TeamListDto extends PickType(Team, [
+  ...baseDtoKey,
+  'name',
+  'descriptionTitle',
+  'descriptionContent',
+]) {
+  member: string[];
+}
+
+export class GetTeamListResponseDto {
+  teams: TeamListDto[];
+}

--- a/src/services/team/dto/get-team-list.dto.ts
+++ b/src/services/team/dto/get-team-list.dto.ts
@@ -8,8 +8,14 @@ class TeamListDto extends PickType(Team, [
   'descriptionTitle',
   'descriptionContent',
 ]) {
+  @ApiProperty({ description: '팀장' })
+  leader: string;
+
   @ApiProperty({ description: '팀원' })
   member: string[];
+
+  @ApiProperty({ description: '팀 소개 링크' })
+  links: string[];
 }
 
 export class GetTeamListResponseDto {

--- a/src/services/team/dto/get-team.dto.ts
+++ b/src/services/team/dto/get-team.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { baseDtoKey } from 'src/entities/base.entity';
+import { Team } from 'src/entities/team.entity';
+
+class GetTeamDto extends PickType(Team, [
+  ...baseDtoKey,
+  'name',
+  'descriptionTitle',
+  'descriptionContent',
+  'links',
+]) {
+  leader: string;
+  member: string[];
+}
+
+export class GetTeamResponseDto {
+  @ApiProperty({ type: GetTeamDto })
+  team: GetTeamDto;
+}

--- a/src/services/team/dto/post-team.dto.ts
+++ b/src/services/team/dto/post-team.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { Team } from 'src/entities/team.entity';
+
+class PostTeamDto extends PickType(Team, [
+  'name',
+  'descriptionTitle',
+  'descriptionContent',
+]) {
+  @ApiProperty({ description: '팀원 id 목록' })
+  member: string[];
+}
+
+export class PostTeamRequestDto {
+  @ApiProperty({ type: PostTeamDto })
+  team: PostTeamDto;
+}
+
+export class PostTeamResponseDto {
+  @ApiProperty({ description: '생성된 팀의 id' })
+  id: string;
+}

--- a/src/services/team/dto/post-team.dto.ts
+++ b/src/services/team/dto/post-team.dto.ts
@@ -8,6 +8,9 @@ class PostTeamDto extends PickType(Team, [
 ]) {
   @ApiProperty({ description: '팀원 id 목록' })
   member: string[];
+
+  @ApiProperty({ description: '팀 소개 링크' })
+  links: string[];
 }
 
 export class PostTeamRequestDto {

--- a/src/services/team/team.service.ts
+++ b/src/services/team/team.service.ts
@@ -1,3 +1,5 @@
+import { link } from 'fs';
+
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Team } from 'src/entities/team.entity';
@@ -22,15 +24,19 @@ export class TeamService {
   ) {}
 
   async findAll(): Promise<GetTeamListResponseDto> {
-    const teams = await this.teamRepository.find();
+    const teams = await this.teamRepository.find({
+      relations: ['member', 'leader', 'links'],
+    });
 
     return {
       teams: teams.map((team) => ({
         id: team.id,
         name: team.name,
+        leader: team.leader.username,
         member: team.member.map((user) => user.username),
         descriptionTitle: team.descriptionTitle,
         descriptionContent: team.descriptionContent,
+        links: team.links.map((link) => link.link),
         updatedAt: team.updatedAt,
         createdAt: team.createdAt,
       })),

--- a/src/services/team/team.service.ts
+++ b/src/services/team/team.service.ts
@@ -58,10 +58,8 @@ export class TeamService {
       name: team.name,
       descriptionTitle: team.descriptionTitle,
       descriptionContent: team.descriptionContent,
+      leader,
     });
-
-    leader.leadTeams.push(newTeam);
-    await this.UserRepository.save(leader);
 
     member.forEach((user) => {
       user.teams.push(newTeam);

--- a/src/services/team/team.service.ts
+++ b/src/services/team/team.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Team } from 'src/entities/team.entity';
+import { Repository } from 'typeorm';
+
+import { GetTeamListResponseDto } from './dto/get-team-list.dto';
+
+@Injectable()
+export class TeamService {
+  constructor(
+    @InjectRepository(Team)
+    private readonly teamRepository: Repository<Team>,
+  ) {}
+
+  async findAll(): Promise<GetTeamListResponseDto> {
+    const teams = await this.teamRepository.find();
+
+    return {
+      teams: teams.map((team) => ({
+        id: team.id,
+        name: team.name,
+        member: team.member.map((user) => user.username),
+        descriptionTitle: team.descriptionTitle,
+        descriptionContent: team.descriptionContent,
+        updatedAt: team.updatedAt,
+        createdAt: team.createdAt,
+      })),
+    };
+  }
+}

--- a/src/services/team/team.service.ts
+++ b/src/services/team/team.service.ts
@@ -8,6 +8,7 @@ import { Repository } from 'typeorm';
 
 import { TeamLink } from './../../entities/team-link.entity';
 import { GetTeamListResponseDto } from './dto/get-team-list.dto';
+import { GetTeamResponseDto } from './dto/get-team.dto';
 import { PostTeamRequestDto, PostTeamResponseDto } from './dto/post-team.dto';
 
 @Injectable()
@@ -79,5 +80,26 @@ export class TeamService {
     );
 
     return { id: newTeam.id };
+  }
+
+  async findTeamById(id: string): Promise<GetTeamResponseDto> {
+    const team = await this.teamRepository.findOne({
+      relations: ['member', 'leader', 'links'],
+      where: { id: id },
+    });
+
+    return {
+      team: {
+        id: team.id,
+        name: team.name,
+        leader: team.leader.username,
+        member: team.member.map((user) => user.username),
+        descriptionTitle: team.descriptionTitle,
+        descriptionContent: team.descriptionContent,
+        links: team.links,
+        updatedAt: team.updatedAt,
+        createdAt: team.createdAt,
+      },
+    };
   }
 }

--- a/src/services/team/team.service.ts
+++ b/src/services/team/team.service.ts
@@ -4,6 +4,7 @@ import { Team } from 'src/entities/team.entity';
 import { User } from 'src/entities/user.entity';
 import { Repository } from 'typeorm';
 
+import { TeamLink } from './../../entities/team-link.entity';
 import { GetTeamListResponseDto } from './dto/get-team-list.dto';
 import { PostTeamRequestDto, PostTeamResponseDto } from './dto/post-team.dto';
 
@@ -12,6 +13,9 @@ export class TeamService {
   constructor(
     @InjectRepository(Team)
     private readonly teamRepository: Repository<Team>,
+
+    @InjectRepository(TeamLink)
+    private readonly teamLinkRepository: Repository<TeamLink>,
 
     @InjectRepository(User)
     private readonly UserRepository: Repository<User>,
@@ -53,6 +57,12 @@ export class TeamService {
       leader,
       member,
     });
+
+    await Promise.all(
+      team.links.map((link) => {
+        return this.teamLinkRepository.save({ link: link, team: newTeam });
+      }),
+    );
 
     return { id: newTeam.id };
   }


### PR DESCRIPTION
## 관련이슈

- #45 

## 요약

- 팀 전체 조회, 팀 정보 조회, 팀 생성 api

## 상세

- 존재하는 전체 팀 목록을 조회하는 api
- 팀 id를 통해 특정 팀을 조회하는 api
- 팀을 생성하는 api
- 팀 소개 링크를 저장하는 테이블 생성

## 리뷰안내

- 리뷰 예상 소요 시간: 20분
- 참고사항
  - 팀 소개 링크 삭제 api 필요
  - 팀 삭제 api 필요
  - 팀 정보 업데이트 api 필요